### PR TITLE
Adding the CGO_ENABLED to all lambdas

### DIFF
--- a/createFeatureFlag/Makefile
+++ b/createFeatureFlag/Makefile
@@ -1,0 +1,3 @@
+build-CreateFeatureFlagFunction:
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bootstrap
+	cp ./bootstrap $(ARTIFACTS_DIR)/.

--- a/createUserFeatureFlag/Makefile
+++ b/createUserFeatureFlag/Makefile
@@ -1,0 +1,3 @@
+build-CreateUserFeatureFlagFunction:
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bootstrap
+	cp ./bootstrap $(ARTIFACTS_DIR)/.

--- a/getAllFeatureFlags/Makefile
+++ b/getAllFeatureFlags/Makefile
@@ -1,0 +1,3 @@
+build-GetAllFeatureFlagFunction:
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bootstrap
+	cp ./bootstrap $(ARTIFACTS_DIR)/.

--- a/getUserFeatureFlag/Makefile
+++ b/getUserFeatureFlag/Makefile
@@ -1,0 +1,3 @@
+build-GetUserFeatureFlagFunction:
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bootstrap
+	cp ./bootstrap $(ARTIFACTS_DIR)/.

--- a/getUserFeatureFlags/Makefile
+++ b/getUserFeatureFlags/Makefile
@@ -1,0 +1,3 @@
+build-GetUserFeatureFlagsFunction:
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bootstrap
+	cp ./bootstrap $(ARTIFACTS_DIR)/.

--- a/health-check/Makefile
+++ b/health-check/Makefile
@@ -1,0 +1,3 @@
+build-HealthCheckFunction:
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bootstrap
+	cp ./bootstrap $(ARTIFACTS_DIR)/.

--- a/rateLimiterLambda/Makefile
+++ b/rateLimiterLambda/Makefile
@@ -1,0 +1,3 @@
+build-RateLimiterFunction:
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bootstrap
+	cp ./bootstrap $(ARTIFACTS_DIR)/.

--- a/template.yaml
+++ b/template.yaml
@@ -19,7 +19,7 @@ Resources:
   HealthCheckFunction:
     Type: 'AWS::Serverless::Function'
     Metadata:
-      BuildMethod: go1.x
+      BuildMethod: makefile
     Properties:
       CodeUri: health-check/
       Handler: bootstrap
@@ -36,7 +36,7 @@ Resources:
   RateLimiterFunction:
     Type: 'AWS::Serverless::Function'
     Metadata:
-      BuildMethod: go1.x
+      BuildMethod: makefile
     Properties:
       CodeUri: rateLimiterLambda/
       Handler: bootstrap
@@ -70,7 +70,7 @@ Resources:
   CreateFeatureFlagFunction:
     Type: 'AWS::Serverless::Function'
     Metadata:
-      BuildMethod: go1.x  
+      BuildMethod: makefile
     Properties:
       CodeUri: createFeatureFlag/
       Handler: bootstrap
@@ -87,7 +87,7 @@ Resources:
   UpdateFeatureFlagFunction:
     Type: 'AWS::Serverless::Function'
     Metadata:
-      BuildMethod: go1.x
+      BuildMethod: makefile
     Properties:
       CodeUri: updateFeatureFlag/
       Handler: bootstrap
@@ -104,7 +104,7 @@ Resources:
   GetAllFeatureFlagFunction:
     Type: 'AWS::Serverless::Function'
     Metadata:
-      BuildMethod: go1.x
+      BuildMethod: makefile
     Properties:
       CodeUri: getAllFeatureFlags/
       Handler: bootstrap
@@ -121,7 +121,7 @@ Resources:
   GetUserFeatureFlagFunction:
     Type: 'AWS::Serverless::Function'
     Metadata:
-      BuildMethod: go1.x
+      BuildMethod: makefile
     Properties:
       CodeUri: getUserFeatureFlag/
       Handler: bootstrap
@@ -138,7 +138,7 @@ Resources:
   GetUserFeatureFlagsFunction:
     Type: 'AWS::Serverless::Function'
     Metadata:
-      BuildMethod: go1.x
+      BuildMethod: makefile
     Properties:
       CodeUri: getUserFeatureFlags/
       Handler: bootstrap
@@ -155,7 +155,7 @@ Resources:
   CreateUserFeatureFlagFunction:
     Type: 'AWS::Serverless::Function'
     Metadata:
-      BuildMethod: go1.x
+      BuildMethod: makefile
     Properties:
       CodeUri: createUserFeatureFlag/
       Handler: bootstrap
@@ -172,7 +172,7 @@ Resources:
   UpdateUserFeatureFlagFunction:
     Type: 'AWS::Serverless::Function'
     Metadata:
-      BuildMethod: go1.x
+      BuildMethod: makefile
     Properties:
       CodeUri: updateUserFeatureFlag/
       Handler: bootstrap

--- a/updateFeatureFlag/Makefile
+++ b/updateFeatureFlag/Makefile
@@ -1,0 +1,3 @@
+build-UpdateFeatureFlagFunction:
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bootstrap
+	cp ./bootstrap $(ARTIFACTS_DIR)/.

--- a/updateUserFeatureFlag/Makefile
+++ b/updateUserFeatureFlag/Makefile
@@ -1,0 +1,3 @@
+build-UpdateUserFeatureFlagFunction:
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bootstrap
+	cp ./bootstrap $(ARTIFACTS_DIR)/.


### PR DESCRIPTION
This change is done to fix the error faced in the lambdas in AWS console

```


/var/task/bootstrap: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by /var/task/bootstrap)
```