### PR TITLE
add: support staging and production lambda ARNs

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -61,7 +61,7 @@ jobs:
             --s3-bucket ${ARTIFACTS_BUCKET} \
             --region ${REGION} \
             --output-template-file packaged.yaml
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: packaged.yaml
           path: packaged.yaml
@@ -100,6 +100,7 @@ jobs:
           CLOUDFORMATION_EXECUTION_ROLE: ${{ secrets.CLOUDFORMATION_EXECUTION_ROLE }}
           PIPELINE_STACK_NAME: ${{ secrets.STACK_NAME }}
           REGION: ${{ secrets.REGION }}
+          ENVIRONMENT: ${{ needs.prepare.outputs.branch_name == 'main' && 'PRODUCTION' || 'DEVELOPMENT' }}
         run: |
           sam deploy --stack-name ${PIPELINE_STACK_NAME} \
             --no-confirm-changeset \
@@ -108,4 +109,5 @@ jobs:
             --region ${REGION} \
             --s3-bucket ${ARTIFACTS_BUCKET} \
             --no-fail-on-empty-changeset \
+            --parameter-overrides Environment=${ENVIRONMENT} \
             --role-arn ${CLOUDFORMATION_EXECUTION_ROLE}

--- a/template.yaml
+++ b/template.yaml
@@ -4,16 +4,54 @@ Globals:
     Timeout: 10
     Environment:
       Variables:
-        ENVIRONMENT: PRODUCTION
-        CreateFeatureFlagFunction: FeatureFlagBackendProdLam-CreateFeatureFlagFunctio-YOVQpOQ9W4hR
-        CreateUserFeatureFlagFunction: FeatureFlagBackendProdLam-CreateUserFeatureFlagFun-Fi1GnCD4KsBu
-        GetFeatureFlagFunction: FeatureFlagBackendProdLambd-GetFeatureFlagFunction-I2kT1C4qt7i8
-        GetAllFeatureFlagFunction: FeatureFlagBackendProdLam-GetAllFeatureFlagFunctio-kqYPpHWHnPqR
-        UpdateFeatureFlagFunction: FeatureFlagBackendProdLam-UpdateFeatureFlagFunctio-9g8Vbr3cPzHL
-        UpdateUserFeatureFlagFunction: FeatureFlagBackendProdLam-UpdateUserFeatureFlagFun-FkeJ3SHwYIjo
-        GetUserFeatureFlagsFunction: FeatureFlagBackendProdLam-GetUserFeatureFlagsFunct-Qj4UvchESEwz
-        GetUserFeatureFlagFunction: FeatureFlagBackendProdLam-GetUserFeatureFlagFuncti-X4iHFCSiLo92
-        RateLimiterFunction: FeatureFlagBackendProdLambdas-RateLimiterFunction-WubbBb4Naxsm
+        ENVIRONMENT: !Ref Environment
+        CreateFeatureFlagFunction: !If
+          - IsProd
+          - FeatureFlagBackendProdLam-CreateFeatureFlagFunctio-YOVQpOQ9W4hR
+          - feature-flag-staging-CreateFeatureFlagFunction-jtNqeZdpSPyX
+        CreateUserFeatureFlagFunction: !If
+          - IsProd
+          - FeatureFlagBackendProdLam-CreateUserFeatureFlagFun-Fi1GnCD4KsBu
+          - feature-flag-staging-CreateUserFeatureFlagFunction-STwgvxNezRhr
+        GetFeatureFlagFunction: !If
+          - IsProd
+          - FeatureFlagBackendProdLambd-GetFeatureFlagFunction-I2kT1C4qt7i8
+          - feature-flag-staging-GetFeatureFlagFunction-0J7rpugeOdU5
+        GetAllFeatureFlagFunction: !If
+          - IsProd
+          - FeatureFlagBackendProdLam-GetAllFeatureFlagFunctio-kqYPpHWHnPqR
+          - feature-flag-staging-GetAllFeatureFlagFunction-ey71dNmZRDOp
+        UpdateFeatureFlagFunction: !If
+          - IsProd
+          - FeatureFlagBackendProdLam-UpdateFeatureFlagFunctio-9g8Vbr3cPzHL
+          - feature-flag-staging-UpdateFeatureFlagFunction-Kyi46ClC6I4R
+        UpdateUserFeatureFlagFunction: !If
+          - IsProd
+          - FeatureFlagBackendProdLam-UpdateUserFeatureFlagFun-FkeJ3SHwYIjo
+          - feature-flag-staging-UpdateUserFeatureFlagFunction-CmettJMSor9w
+        GetUserFeatureFlagsFunction: !If
+          - IsProd
+          - FeatureFlagBackendProdLam-GetUserFeatureFlagsFunct-Qj4UvchESEwz
+          - feature-flag-staging-GetUserFeatureFlagsFunction-ajPGREFbovxq
+        GetUserFeatureFlagFunction: !If
+          - IsProd
+          - FeatureFlagBackendProdLam-GetUserFeatureFlagFuncti-X4iHFCSiLo92
+          - feature-flag-staging-GetUserFeatureFlagFunction-8NRHy9k0q5M4
+        RateLimiterFunction: !If
+          - IsProd
+          - FeatureFlagBackendProdLambdas-RateLimiterFunction-WubbBb4Naxsm
+          - feature-flag-staging-RateLimiterFunction-7tOfBleMOdAA
+
+Conditions:
+  IsProd: !Equals [!Ref Environment, "PRODUCTION"]
+
+Parameters:
+  Environment:
+    Type: String
+    Default: "PRODUCTION"
+    AllowedValues:
+      - "PRODUCTION"
+      - "DEVELOPMENT"
 
 Resources:
   HealthCheckFunction:


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 15 September 2024
<!--Developer Name Here-->
Developer Name: @MehulKChaudhari 

---

## Issue Ticket Number
#121 

## Description

The Lambda ARNs used to interact with other Lambda functions for modifying concurrency limits are currently hardcoded for the production environment in the template.yaml file. This hardcoding leads to potential issues when working in different environments (e.g., staging) where different ARNs are required. This makes it difficult to manage and deploy changes across environments without manual updates to the template.

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->
