### PR TITLE
Refactor: Replace hardcoded public key parameter with environment-specific names

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -5,6 +5,10 @@ Globals:
     Environment:
       Variables:
         ENVIRONMENT: PRODUCTION
+        RDS_BACKEND_PUBLIC_KEY_NAME: !If
+          - IsProd
+          - "rdsbackendpublickeyprod"
+          - "rdsbackendpublickeystaging"
         SESSION_COOKIE_NAME: !If
           - IsProd
           - "rds-session"

--- a/utils/Constants.go
+++ b/utils/Constants.go
@@ -20,7 +20,10 @@ const (
 	UserId                               = "userId"
 	FlagId                               = "flagId"
 	ConcurrencyDisablingLambda           = 0
-	SESSION_COOKIE_NAME_PROD       = "rds-session"
-	SESSION_COOKIE_NAME_DEV        = "rds-session-staging"
-	SESSION_COOKIE_NAME_LOCAL      = "rds-session-development"
+	SESSION_COOKIE_NAME_PROD             = "rds-session"
+	SESSION_COOKIE_NAME_DEV              = "rds-session-staging"
+	SESSION_COOKIE_NAME_LOCAL            = "rds-session-development"
+	RDS_BACKEND_PUBLIC_KEY_NAME_DEV      = "rdsbackendpublickeystaging"
+	RDS_BACKEND_PUBLIC_KEY_NAME_PROD     = "rdsbackendpublickeyprod"
+	RDS_BACKEND_PUBLIC_KEY_NAME_LOCAL    = "publickey"
 )


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 15/Jan/2025
<!--Developer Name Here-->
Developer Name: @MehulKChaudhari 

---
## Issue Ticket Number
- Closes #138 

## Description
Currently, the public key parameter name is hardcoded as "publicKey," which is too generic and could cause confusion.  
This PR updates the JWT package to use more specific names like `rdsBackendPublicKeyStaging` based on the environment.

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

