### PR TITLE
fix: RDS backend public key parameter name

### DIFF
--- a/utils/Constants.go
+++ b/utils/Constants.go
@@ -23,7 +23,7 @@ const (
 	SESSION_COOKIE_NAME_PROD             = "rds-session"
 	SESSION_COOKIE_NAME_DEV              = "rds-session-staging"
 	SESSION_COOKIE_NAME_LOCAL            = "rds-session-development"
-	RDS_BACKEND_PUBLIC_KEY_NAME_DEV      = "rdsbackendpublickeystaging"
-	RDS_BACKEND_PUBLIC_KEY_NAME_PROD     = "rdsbackendpublickeyprod"
+	RDS_BACKEND_PUBLIC_KEY_NAME_DEV      = "STAGING_RDS_BACKEND_PUBLIC_KEY"
+	RDS_BACKEND_PUBLIC_KEY_NAME_PROD     = "PROD_RDS_BACKEND_PUBLIC_KEY"
 	RDS_BACKEND_PUBLIC_KEY_NAME_LOCAL    = "publickey"
 )


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 20/Jan/2025
<!--Developer Name Here-->
Developer Name: @MehulKChaudhari 

---

## Description
The parameter is named `STAGING_RDS_BACKEND_PUBLIC_KEY` in the codebase to align with its AWS parameter store.

### Documentation Updated?

- [ ] Yes
- [ ] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No