### PR TITLE
Updating Github actions as the older OS version has been deprecated.

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -12,7 +12,7 @@ env:
 jobs:
   prepare:
     name: Prepare
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Inject slug/short variables


### PR DESCRIPTION
Ref : https://github.com/actions/runner-images/issues/11101

<!-- Date Here in dd mmm yyyy-->
Date: 29th April
<!--Developer Name Here-->
Developer Name: Vikhyat

---

## Issue Ticket Number
This ticket fixes the broken Github actions pipeline, we are making this change as the deployment which we tried doing yesterday didn't suceed

## Description

The current version of our Ubuntu OS is deprecated so we had to update the OS version in the GA

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [ ] Yes
- [x] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
